### PR TITLE
fix #61

### DIFF
--- a/src/main/webapp/scripts/mode/ceylon/ceylon.js
+++ b/src/main/webapp/scripts/mode/ceylon/ceylon.js
@@ -60,7 +60,7 @@ CodeMirror.defineMode("ceylon", function(config, parserConfig) {
   function jsTokenBase(stream, state) {
     var ch = stream.next();
     if (ch == '"' || ch == '`' && stream.eat('`')) {
-      if (stream.eat('""')) {
+      if (stream.match('""')) {
           return chain(stream, state, jsTokenVerbatim);
       }
       else {


### PR DESCRIPTION
CodeMirror’s `eat` can only be used to match single characters; `match` is the multi-character version.
