### PR TITLE
"Fix" #60: Example 10 "Enumerations" broken

### DIFF
--- a/src/main/webapp/examples/switch1.ceylon
+++ b/src/main/webapp/examples/switch1.ceylon
@@ -35,8 +35,12 @@ void printTree(Node root) {
 }
 printTree(tree);
 
-// Object enumerations are also possible:
-abstract class Color(name) of red | green | blue {
+// Object enumerations are also possible;
+// however, they currently don't work in the web IDE due to
+// https://github.com/ceylon/ceylon-web-ide-backend/issues/58
+// Note that this is only a restriction of the web IDE:
+// it works on both the Java and JavaScript backends.
+abstract class Color(name) /* of red | green | blue */ {
     shared String name;
 }
 object red extends Color("red") {}


### PR DESCRIPTION
Object enumerations are still broken due to #58, so this removes the case types from `Color` and adds a comment explaining why.

This solution sucks, but #60 has been open for over five months now, and the problem exists even longer. We can’t have an example that doesn’t compile – we need _some_ solution.

Closes #60 for now.
