### PR TITLE
Update collections example for Ceylon 1.1

### DIFF
--- a/src/main/webapp/examples/collections.ceylon
+++ b/src/main/webapp/examples/collections.ceylon
@@ -1,6 +1,6 @@
 // A constant, read-only sequence of values:
 String[] animals = [ "elephant", "parrot", "giraffe" ];
-String[] none = {}; // empty sequence
+String[] none = []; // empty sequence
 
 // Accessing the sequence returns an optional value (String?)
 print("First: ``animals.first else "none"``");


### PR DESCRIPTION
In Ceylon 1.1, `{}` is different from `[]` and stands only for an empty `Iterable`, not for an empty `Sequential`.
