### PR TITLE
Add missing startsWith/endsWith in safari

### DIFF
--- a/src/main/webapp/scripts/repl.js
+++ b/src/main/webapp/scripts/repl.js
@@ -66,6 +66,25 @@ var live_tc = {
     }
 };
 
+if (typeof String.prototype.startsWith != 'function') {
+    String.prototype.startsWith = function(prefix, position) {
+        position = position || 0;
+        return this.indexOf(prefix, position) === position;
+    }
+}
+
+if (typeof String.prototype.endsWith != 'function') {
+    String.prototype.endsWith = function(searchString, position) {
+        var subjectString = this.toString();
+        if (position === undefined || position > subjectString.length) {
+            position = subjectString.length;
+        }
+        position -= searchString.length;
+        var lastIndex = subjectString.indexOf(searchString, position);
+        return lastIndex !== -1 && lastIndex === position;
+    };
+}
+
 var pagepath = window.location.pathname;
 if (!pagepath.endsWith("/")) {
     var p = pagepath.lastIndexOf("/");

--- a/src/main/webapp/scripts/runner.js
+++ b/src/main/webapp/scripts/runner.js
@@ -2,6 +2,25 @@
 
 var clprinted = false;
 
+if (typeof String.prototype.startsWith != 'function') {
+    String.prototype.startsWith = function(prefix, position) {
+        position = position || 0;
+        return this.indexOf(prefix, position) === position;
+    }
+}
+
+if (typeof String.prototype.endsWith != 'function') {
+    String.prototype.endsWith = function(searchString, position) {
+        var subjectString = this.toString();
+        if (position === undefined || position > subjectString.length) {
+            position = subjectString.length;
+        }
+        position -= searchString.length;
+        var lastIndex = subjectString.indexOf(searchString, position);
+        return lastIndex !== -1 && lastIndex === position;
+    };
+}
+
 var pagepath = window.location.pathname;
 if (!pagepath.endsWith("/")) {
     var p = pagepath.lastIndexOf("/");


### PR DESCRIPTION
The web IDE uses `startsWith` and `endsWith` that are [part of ES6](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith), and are not implemented on certain browsers (for example Safari). This PR adds polyfills in case those functions don't exist in the browser.